### PR TITLE
Cloug WG: SUSE is now written with all caps

### DIFF
--- a/working_groups/wg-Cloud/meeting-notes/2019-06-14.md
+++ b/working_groups/wg-Cloud/meeting-notes/2019-06-14.md
@@ -7,7 +7,7 @@
 * Peter Norton: interested in improving the usability of salt-cloud
 * Tyler Johnson: working for saltstack on core
 * Swaminathan: certs in aws and salt and works with vmware too. Exp. with chef and interested in helping improve salt-cloud.
-* Cedric Bosdonnat: Works for SuSE and contributes to libvirt. Improve salt's libvirt support.
+* Cedric Bosdonnat: Works for SUSE and contributes to libvirt. Improve salt's libvirt support.
 
 * Nick Garber (attended, intro not made)
 


### PR DESCRIPTION
`SuSE` looks so old that I couldn't refrain from correcting it ;)