### PR TITLE
Remove `doc` salt tool prereq for repo contrib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # SaltStack Community
 
-Don't update the Readme files directly. Check the doc folder to see instructions on how to update
-
 ## Working Groups
 
 A Working Group is a small group of individuals who come together with a common goal and work towards achieving that goal within a predetermined amount of time. It’s an opportunity for the Salt community to lead Salt projects and be part of the process in its entirety.

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,4 +1,8 @@
 # Doc Generation 
+
+> **NOTE**: _This README can be ignored, as `salt` is no longer a prereq tool to_
+> _contribute to this repo._
+
 ## How to Generate Docs
 * Install Salt.
 * Open a terminal with admin privileges. 


### PR DESCRIPTION
Remove wording that directs people to needing to install and run a tool requiring salt and salt state configurations for contributors.