### PR TITLE
Add meeting notes for 2021-06-09

### DIFF
--- a/working_groups/wg-Release/meeting-notes/2021-06-09.md
+++ b/working_groups/wg-Release/meeting-notes/2021-06-09.md
@@ -1,29 +1,27 @@
-file: salt_release_coordination_minutes_2021-06-09.txt
-created: 2021-06-10 donfede@casagrau.org
-updated: 2021-06-13 donfede@casagrau.org
-desc: minutes 
-####
+# 2021-06-09 WG Release Meeting
+
+topic: Salt Release Coordination Community Meeting  
+date: 2021-06-09  
+time: 17:00 CEST (UTC+2)  
+where: zoom online meeting, hosted by VMware  
 
 
-topic: Salt Release Coordination Community Meeting
-date: 2021-06-09
-time: 17:00 CEST (UTC+2)
-where: zoom online meeting, hosted by VMware
+# Attendees (8x)
 
-# Attendees (8x) [see slide 01]
-  Sage Robins (Host) ["VMware"]
-  Pablo Suarez Henandez [SUSE; ran the meeting]
-  Bengamin [?Drung ; Debian DD Salt packager]
-  donfede Fede Grau (Debian community member Salt team)
-  Alexander Graul [SUSE]
-  Patrick McLean [?]
-  Randy Thompson ["GoDaddy"; salt/tiamat]
-  Victor Zhestkov [?]      
+* Bengamin Drung (Debian DD Salt packager)
+* Fede Grau (Debian community member Salt team) @donfede
+*  Alexander Graul (SUSE)
+* Patrick McLean (Gentoo)
+* Sage Robins (VMware Salt) @sagetherage
+* Pablo Suárez Hernández (SUSE; led the meeting) @meaksh
+* Randy Thompson (GoDaddy; salt/Tiamat)
+* Victor Zhestkov @vzhestkov
+
 
 # Agenda
  - walkthrough of how doing releases of Salt at SUSE
  - goals to do the same with other distros, aiming to learn and improve
- - maybe tiamen review
+ - maybe Tiamat review
 
 
 # Notes

--- a/working_groups/wg-Release/meeting-notes/2021-06-09.md
+++ b/working_groups/wg-Release/meeting-notes/2021-06-09.md
@@ -27,7 +27,7 @@ where: zoom online meeting, hosted by VMware
 
 
 # Notes
- - (PH) reviewed agenda 
+ - (PSH) reviewed agenda 
     [see slide 02; 
         https://github.com/saltstack/community/projects/60 
         https://github.com/saltstack/community/issues/143 ]
@@ -98,8 +98,8 @@ where: zoom online meeting, hosted by VMware
      - Debian has ~15-20 currently; SUSE has hundreds
      - ideally upstream patches have open MR/PR
      - AG "SUSE tries to present patches upstream" "some patches are SUSE specific"
-     - PH "SUSE procedures require upstream PR with patches"
-   - PH review next meeting action items [see below]
+     - PSH "SUSE procedures require upstream PR with patches"
+   - PSH review next meeting action items [see below]
      - check if there is interest in OBS quick intro?
    - next meeting in 1 month [FIXME: actual date]
 

--- a/working_groups/wg-Release/meeting-notes/2021-06-09.txt
+++ b/working_groups/wg-Release/meeting-notes/2021-06-09.txt
@@ -1,0 +1,113 @@
+file: salt_release_coordination_minutes_2021-06-09.txt
+created: 2021-06-10 donfede@casagrau.org
+updated: 2021-06-13 donfede@casagrau.org
+desc: minutes 
+####
+
+
+topic: Salt Release Coordination Community Meeting
+date: 2021-06-09
+time: 17:00 CEST (UTC+2)
+where: zoom online meeting, hosted by VMware
+
+# Attendees (8x) [see slide 01]
+  Sage Robins (Host) ["VMware"]
+  Pablo Suarez Henandez [SUSE; ran the meeting]
+  Bengamin [?Drung ; Debian DD Salt packager]
+  donfede Fede Grau (Debian community member Salt team)
+  Alexander Graul [SUSE]
+  Patrick McLean [?]
+  Randy Thompson ["GoDaddy"; salt/tiamat]
+  Victor Zhestkov [?]      
+
+# Agenda
+ - walkthrough of how doing releases of Salt at SUSE
+ - goals to do the same with other distros, aiming to learn and improve
+ - maybe tiamen review
+
+
+# Notes
+ - (PH) reviewed agenda 
+    [see slide 02; 
+        https://github.com/saltstack/community/projects/60 
+        https://github.com/saltstack/community/issues/143 ]
+ - (AG screenshare) walkthrough of SUSE Salt release process
+    [see slide 03;
+        https://github.com/openSUSE/salt/wiki#opensuse-salt-packaging ]
+    - SUSE supports multiple distributions, including openSUSE and SUSE Linux Enterprise
+    - use "OBS" (Open Build Service; [not Open Broadcast Software]) to build
+    - new Salt releases amounts to creating new branch on openSUSE
+    [see slide 04;
+        https://github.com/openSUSE/salt-packaging/tree/3000/salt ]
+    - helper tool generates patches, in a different repo (Git on github)
+    - SUSE uses upstream tarball as is, with patches on top
+    - Git commit messages, often a single line, are used to autogenerate Changelog
+    - OBS can build containers and OS images
+    [see slide 05:
+        https://build.opensuse.org/project/show/systemsmanagement:saltstack:products ]
+    - due to "political reasons", SUSE does not change the version number
+    - RPM spec file quick review
+    - "MU branches are complicated" [seem ok to ignore initially]
+    - OBS follows a similar process to Git with "branches"
+    - OBS uses a "service" file
+    [see slide 06]
+    - OBS also builds for different distributions, including CentOS, Fedora, Ubuntu
+    - "nothing from pip is used directly; only SUSE's own validated RPMs"
+
+ - Q/A for walkthrough of SUSE Salt release process
+    - BD Q - "version number review"
+        "upstream version-release.rebuild"
+
+    - FG Q - "do you package full Salt or just minion client for other distros,
+      and why? are Windows builds included?"
+        [answered in part by OBS screenshare; full Salt is built if possible]
+        "SUSE builds various Salt packages for another software product they
+        support 'uyuni' (spacewalk successor)
+        [ https://www.uyuni-project.org/ ]
+        "no current support for Windows"
+
+    - FG Q - "are repos accessed only by SUSE employees, or also community?"
+        "SUSE uses open development model hosted on github, and are open to
+        community contributions; though few are received"
+        "in OBS members have 'submit' and 'review' process, much like Git and github"
+     [see slide 07
+        https://build.opensuse.org/package/requests/systemsmanagement:saltstack:products:testing/salt ]
+
+
+ - (17:30) (Randy) impromptu review of "tiamat"
+    [ ? https://gitlab.com/saltstack/pop/tiamat ]
+    - overview "pop wrapper to pi-installer"; helps build any codebase
+    - pulls in all deps via requriments, source package
+    - also includes shared libraries (optional)
+    - creates a dynamic binary, "staticx"
+    [ ? https://pypi.org/project/staticx/ ]
+    - still in beta; systemd bug starting
+    - tiamat is used at GoDadddy
+    - BD Q - purpose?
+        "easier deployment of Salt, via a single binary for master, minion"
+        "lower entry to deploy code"
+    - unclear if a Salt Project priority, but GoDaddy is using it
+    - shared library security patches can optionally be used
+    - pip security updates, "pip install within binary"
+    - RT has some ideas to support SUSE model of using RPMs instead of pip
+    - regular tiamat contributors include "Pedro, RT, and ?'karl'"
+
+
+ - (17:45) Open Table
+   - BD "patches" and getting all patches upstream
+     - Debian has ~15-20 currently; SUSE has hundreds
+     - ideally upstream patches have open MR/PR
+     - AG "SUSE tries to present patches upstream" "some patches are SUSE specific"
+     - PH "SUSE procedures require upstream PR with patches"
+   - PH review next meeting action items [see below]
+     - check if there is interest in OBS quick intro?
+   - next meeting in 1 month [FIXME: actual date]
+
+
+# Action Items
+ - ?Debian (or Gentoo) prepare presentation of Salt release flow
+   - (FG) could be open to drafting some slides for Debian Salt Team review
+
+ - (17:56) close call
+
+


### PR DESCRIPTION
Meeting notes from 2021-06-09 for wg-Release.
Created subdirectory structure matching other wg.

I had drafted these notes in basic text format before seeing other working groups using .md formatting.  I'll be glad to try future notes in .md format.  Advise if these need to be converted also.